### PR TITLE
add dummy key comment to make GnuPG agent work

### DIFF
--- a/thrussh-keys/src/key.rs
+++ b/thrussh-keys/src/key.rs
@@ -572,7 +572,8 @@ impl agent_key::Private for KeyPair {
                 buf.extend_ssh_string(public);
                 buf.push_u32_be(64);
                 buf.extend(&secret.key);
-                buf.extend_ssh_string(b"");
+                // The GnuPG SSH agent fails to add keys with empty comments.
+                buf.extend_ssh_string(b"key");
             }
             #[cfg(feature = "openssl")]
             KeyPair::RSA { ref key, .. } => {
@@ -590,7 +591,7 @@ impl agent_key::Private for KeyPair {
                 }
                 buf.extend_ssh_mpint(&key.p().unwrap().to_vec());
                 buf.extend_ssh_mpint(&key.q().unwrap().to_vec());
-                buf.extend_ssh_string(b"");
+                buf.extend_ssh_string(b"key");
             }
         }
         Ok(())


### PR DESCRIPTION
The GnuPG SSH agent has a bug where it fails to add keys that have an empty comment string. To work around this issue we add a dummy comment when encoding a secret key for SSH.